### PR TITLE
[Podspec] Remove wrong header dir specification

### DIFF
--- a/NORMarkdownParser.podspec
+++ b/NORMarkdownParser.podspec
@@ -18,6 +18,5 @@ Pod::Spec.new do |s|
   s.frameworks = 'Foundation'
   s.requires_arc = true
 
-  s.header_dir = ''
   s.source_files = 'hoedown/**/*.{h,c}', 'NORMarkdownParser/*.{h,m}'
 end


### PR DESCRIPTION
This is not needed and won't work anymore with the next release.
